### PR TITLE
Cleanup xseed args

### DIFF
--- a/k8s/apps/media/values.yaml
+++ b/k8s/apps/media/values.yaml
@@ -104,25 +104,6 @@ media:
           env:
             PUID: 568
             PGID: 568
-            TZ: Etc/UTC
-          args:
-            - daemon
-            - "-T"
-            - http://media-prowlarr:9696/1/api?apikey=6e4a625420f84dd38d474f3b9664ea1a
-            - http://media-prowlarr:9696/2/api?apikey=6e4a625420f84dd38d474f3b9664ea1a
-            - "-A"
-            - inject
-            - "--qbittorrent-url"
-            - "http://media-qbittorrent:8081"
-            - "--duplicate-categories"
-            - "--match-mode"
-            - "partial"
-            - "--link-dirs"
-            - "/data/x-seed"
-            - "--season-from-episodes"
-            - "0.8"
-            - "--rss-cadence"
-            - "15min"
           probes:
             liveness:
               enabled: true


### PR DESCRIPTION
Removed timezone setting and command-line arguments from the media values.yaml configuration.