### PR TITLE
Exclude cilium-install from kube-job-failed-once alert

### DIFF
--- a/k8s/system/telemetry/templates/vmrule-kube-job-failed.yaml
+++ b/k8s/system/telemetry/templates/vmrule-kube-job-failed.yaml
@@ -10,9 +10,17 @@ spec:
         # Fires only when kube_job_failed changes within the last 6h
         # (i.e. when a Job newly fails). Auto-clears 6h after the last
         # failure event even if the Failed Job object still exists.
+        #
+        # cilium-install is excluded: it's a Talos bootstrap inline manifest
+        # (terraform/cluster/node/manifests/cilium-install.yaml) that runs
+        # `cilium install` on every machineconfig apply and fails by design on
+        # an already-provisioned cluster (Cilium is already present). The image
+        # is distroless so it can't be made idempotent with a shell guard, and
+        # a genuine CNI bootstrap failure on a fresh node surfaces via other
+        # alerts (nodes NotReady, etc.).
         - alert: KubeJobFailed
           expr: |
-            changes(kube_job_failed{job="kube-state-metrics"}[6h]) > 0
+            changes(kube_job_failed{job="kube-state-metrics", job_name!="cilium-install"}[6h]) > 0
           labels:
             severity: warning
           annotations:


### PR DESCRIPTION
The cilium-install bootstrap Job (a Talos inline manifest) runs 'cilium install' on every machineconfig apply and fails by design on an already-provisioned cluster. Its image is distroless (no shell) and 'cilium install' has no skip-if-present flag, so it can't be made idempotent in-place. Exclude it from the alert instead; a genuine CNI bootstrap failure on a fresh node still surfaces via node-NotReady and related alerts.

Verified against live data: the previous expr matched 3 series (all kube-system/cilium-install); the new expr matches 0.