### PR TITLE
hermes-karyna: agent sha-bd23227, provider custom so the proxy is used

### DIFF
--- a/k8s/apps/hermes-karyna/values.yaml
+++ b/k8s/apps/hermes-karyna/values.yaml
@@ -8,7 +8,7 @@ hermes-karyna:
         main:
           image:
             repository: ghcr.io/vanchaxy/hermes-karyna
-            tag: sha-bc4b512
+            tag: sha-bd23227
           env:
             TZ: Europe/Prague
             HINDSIGHT_MODE: local_external


### PR DESCRIPTION
sha-bc4b512 shipped base_url but kept provider "anthropic", which is the direct Anthropic API and ignores base_url. The proxy logged zero requests in an hour while every turn went to api.anthropic.com and 400'd.

sha-bd23227 switches the agent and its auxiliary blocks to provider "custom" with api_mode "anthropic_messages", so the endpoint actually comes from base_url and the Anthropic wire is kept (the OpenAI wire cannot carry image blocks in tool results, which garment intake depends on).


Claude-Session: https://claude.ai/code/session_019UmnjjT65a5RHZr67J6N1L