### PR TITLE
Add openid scope to Kaneo OIDC

### DIFF
--- a/k8s/apps/kaneo/values.yaml
+++ b/k8s/apps/kaneo/values.yaml
@@ -31,6 +31,7 @@ kaneo:
                   name: kaneo-secret
                   key: CUSTOM_OAUTH_CLIENT_SECRET
             CUSTOM_OAUTH_DISCOVERY_URL: https://id.ivanchenko.io/.well-known/openid-configuration
+            CUSTOM_OAUTH_SCOPES: "openid,profile,email"
             S3_ENDPOINT: https://s3.ivanchenko.io
             S3_BUCKET: kaneo
             


### PR DESCRIPTION
Pocket ID v2.10.0 rejects userinfo requests whose access token lacks the openid scope. Kaneo defaults CUSTOM_OAUTH_SCOPES to profile,email, so login failed with "user info is missing".